### PR TITLE
fix: revert back to mounted call

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -261,6 +261,39 @@ function FullyControlledOnClick() {
   );
 }
 
+function NestedSingleton() {
+  const [source, target] = useSingleton({
+    overrides: ['placement'],
+  });
+
+  return (
+    <div>
+      <Tippy
+        content={
+          <div style={{border: '2px solid black'}}>
+            <Tippy
+              singleton={source}
+              delay={500}
+              moveTransition="transform 0.8s cubic-bezier(0.22, 1, 0.36, 1)"
+            />
+            <Tippy content="Hello" singleton={target} placement="bottom">
+              <button>hover me</button>
+            </Tippy>
+            <Tippy content="Hi" singleton={target} placement="bottom">
+              <button>hover me</button>
+            </Tippy>
+          </div>
+        }
+        interactive
+        delay={250}
+        placement="bottom"
+      >
+        <button>hover me test</button>
+      </Tippy>
+    </div>
+  );
+}
+
 function App() {
   return (
     <>
@@ -274,6 +307,8 @@ function App() {
       <Singleton />
       <h2>Singleton Headless</h2>
       <SingletonHeadless />
+      <h2>Nested Singleton</h2>
+      <NestedSingleton />
       <h2>Plugins</h2>
       <FollowCursor />
       <h2>Headless Tippy w/ React Spring</h2>

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -5,7 +5,6 @@ import {
   ssrSafeCreateDiv,
   toDataAttributes,
   deepPreserveProps,
-  isBrowser,
 } from './utils';
 import {useMutableBox, useIsomorphicLayoutEffect} from './util-hooks';
 import {classNamePlugin} from './className-plugin';
@@ -29,6 +28,7 @@ export default function TippyGenerator(tippy) {
     const isControlledMode = visible !== undefined;
     const isSingletonMode = singleton !== undefined;
 
+    const [mounted, setMounted] = useState(false);
     const [attrs, setAttrs] = useState({});
     const [singletonContent, setSingletonContent] = useState();
     const mutableBox = useMutableBox(() => ({
@@ -117,6 +117,8 @@ export default function TippyGenerator(tippy) {
         });
       }
 
+      setMounted(true);
+
       return () => {
         instance.destroy();
         singleton?.cleanup(instance);
@@ -153,7 +155,7 @@ export default function TippyGenerator(tippy) {
         singleton.hook({
           instance,
           content,
-          props,
+          props: computedProps,
         });
       }
     });
@@ -210,7 +212,7 @@ export default function TippyGenerator(tippy) {
               },
             })
           : null}
-        {isBrowser &&
+        {mounted &&
           createPortal(
             render
               ? render(toDataAttributes(attrs), singletonContent)

--- a/test/__snapshots__/Tippy.test.js.snap
+++ b/test/__snapshots__/Tippy.test.js.snap
@@ -25,17 +25,17 @@ Object {
     Object {
       "enabled": true,
       "fn": [Function],
-      "name": "x",
-      "phase": "main",
-    },
-    Object {
-      "enabled": true,
-      "fn": [Function],
       "name": "$$tippyReact",
       "phase": "beforeWrite",
       "requires": Array [
         "computeStyles",
       ],
+    },
+    Object {
+      "enabled": true,
+      "fn": [Function],
+      "name": "x",
+      "phase": "main",
     },
   ],
   "strategy": "fixed",


### PR DESCRIPTION
Fixes console warning #232  (while maintaining the fix for #227) 

Caveat: affects perf as it causes another double render, this time in the `useSingleton` hook.