### PR TITLE
feat: reference prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,24 @@ function App() {
 }
 ```
 
+### `reference?: ref`
+
+If you can't place your reference element as a child inside `<Tippy />`, you can
+use this prop instead.
+
+```jsx
+function App() {
+  const ref = useRef();
+
+  return (
+    <>
+      <button ref={ref}></button>
+      <Tippy content="Tooltip" reference={ref} />
+    </>
+  );
+}
+```
+
 ### Plugins
 
 Tippy.js splits certain props into separate pieces of code called plugins to

--- a/README.md
+++ b/README.md
@@ -297,10 +297,11 @@ function App() {
 }
 ```
 
-### `reference?: ref`
+### `reference?: React.RefObject | Element`
 
 If you can't place your reference element as a child inside `<Tippy />`, you can
-use this prop instead.
+use this prop instead. It can accept a React `RefObject` (`.current` property)
+or a plain `Element`.
 
 ```jsx
 function App() {

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 import {useSpring, animated} from 'react-spring';
@@ -294,6 +294,17 @@ function NestedSingleton() {
   );
 }
 
+function ReferenceProp() {
+  const ref = useRef();
+
+  return (
+    <>
+      <button ref={ref}>Reference</button>
+      <Tippy content="Tippy" reference={ref} />
+    </>
+  );
+}
+
 function App() {
   return (
     <>
@@ -317,6 +328,8 @@ function App() {
       <FramerMotion />
       <h2>Fully Controlled on Click</h2>
       <FullyControlledOnClick />
+      <h2>Reference prop</h2>
+      <ReferenceProp />
     </>
   );
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface TippyProps extends Omit<Partial<Props>, 'content' | 'render'> {
   disabled?: boolean;
   className?: string;
   singleton?: SingletonObject;
-  reference?: React.RefObject<Element> | Element;
+  reference?: React.RefObject<Element> | Element | null;
   render?: (
     attrs: {
       'data-placement': Placement;

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export interface TippyProps extends Omit<Partial<Props>, 'content' | 'render'> {
   disabled?: boolean;
   className?: string;
   singleton?: SingletonObject;
+  reference?: React.RefObject<Element> | Element;
   render?: (
     attrs: {
       'data-placement': Placement;

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -91,7 +91,7 @@ export default function TippyGenerator(tippy) {
       };
     }
 
-    const deps = children ? [children.type] : [];
+    const deps = [reference].concat(children ? [children.type] : []);
 
     // CREATE
     useIsomorphicLayoutEffect(() => {

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -16,6 +16,7 @@ export default function TippyGenerator(tippy) {
     visible,
     singleton,
     render,
+    reference,
     disabled = false,
     ignoreAttributes = true,
     // Filter React development reserved props
@@ -94,10 +95,13 @@ export default function TippyGenerator(tippy) {
 
     // CREATE
     useIsomorphicLayoutEffect(() => {
-      const instance = tippy(mutableBox.ref || ssrSafeCreateDiv(), {
-        ...computedProps,
-        plugins: [classNamePlugin, ...(props.plugins || [])],
-      });
+      const instance = tippy(
+        reference?.current || mutableBox.ref || ssrSafeCreateDiv(),
+        {
+          ...computedProps,
+          plugins: [classNamePlugin, ...(props.plugins || [])],
+        },
+      );
 
       mutableBox.instance = instance;
 

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -95,13 +95,15 @@ export default function TippyGenerator(tippy) {
 
     // CREATE
     useIsomorphicLayoutEffect(() => {
-      const instance = tippy(
-        reference?.current || mutableBox.ref || ssrSafeCreateDiv(),
-        {
-          ...computedProps,
-          plugins: [classNamePlugin, ...(props.plugins || [])],
-        },
-      );
+      let element = reference;
+      if (reference && reference.hasOwnProperty('current')) {
+        element = reference.current;
+      }
+
+      const instance = tippy(element || mutableBox.ref || ssrSafeCreateDiv(), {
+        ...computedProps,
+        plugins: [classNamePlugin, ...(props.plugins || [])],
+      });
 
       mutableBox.instance = instance;
 

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useRef} from 'react';
 import TippyBase from '../src';
 import {render, cleanup} from '@testing-library/react';
 
@@ -497,6 +497,25 @@ describe('<Tippy />', () => {
     render(<Tippy className="x" />);
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('`reference` prop', () => {
+    function App() {
+      const ref = useRef();
+
+      return (
+        <>
+          <button ref={ref} data-testid="reference-prop" />
+          <Tippy reference={ref} />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    expect(instance.reference.getAttribute('data-testid')).toBe(
+      'reference-prop',
+    );
   });
 });
 

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -525,7 +525,7 @@ describe('<Tippy />', () => {
       return (
         <>
           <button ref={setElement} data-testid="reference-prop" />
-          {element ? <Tippy reference={element} /> : null}
+          <Tippy reference={element} />
         </>
       );
     }

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useRef, useState} from 'react';
 import TippyBase from '../src';
 import {render, cleanup} from '@testing-library/react';
 
@@ -499,7 +499,7 @@ describe('<Tippy />', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  test('`reference` prop', () => {
+  test('`reference` prop as RefObject', () => {
     function App() {
       const ref = useRef();
 
@@ -507,6 +507,25 @@ describe('<Tippy />', () => {
         <>
           <button ref={ref} data-testid="reference-prop" />
           <Tippy reference={ref} />
+        </>
+      );
+    }
+
+    render(<App />);
+
+    expect(instance.reference.getAttribute('data-testid')).toBe(
+      'reference-prop',
+    );
+  });
+
+  test('`reference` prop as Element', () => {
+    function App() {
+      const [element, setElement] = useState(null);
+
+      return (
+        <>
+          <button ref={setElement} data-testid="reference-prop" />
+          {element ? <Tippy reference={element} /> : null}
         </>
       );
     }


### PR DESCRIPTION
Closes https://github.com/atomiks/tippyjs-react/issues/213

@potty 
@reywright

Use cases:

1. React.RefObject

```jsx
    function App() {
      const ref = useRef();

      return (
        <>
          <button ref={ref} />
          <Tippy reference={ref} />
        </>
      );
    }
```

2. Element

```jsx
    function App() {
      const [element, setElement] = useState(null);

      return (
        <>
          <button ref={setElement} />
          <Tippy reference={element} />
        </>
      );
    }
```