### PR TITLE
Typescript - added type definition for `ref` prop in TippyProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ export interface TippyProps extends Partial<Omit<Props, 'content' | 'render'>> {
   className?: string;
   singleton?: SingletonObject;
   reference?: React.RefObject<Element> | Element | null;
+  ref?: React.Ref<Element>;
   render?: (
     attrs: {
       'data-placement': Placement;


### PR DESCRIPTION
Fixes #248 