### PR TITLE
feat: pass Tippy instance to render prop

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -221,7 +221,7 @@ export default function TippyGenerator(tippy) {
         {mounted &&
           createPortal(
             render
-              ? render(toDataAttributes(attrs), singletonContent)
+              ? render(toDataAttributes(attrs), singletonContent, mutableBox.current)
               : content,
             mutableBox.container,
           )}

--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -221,7 +221,7 @@ export default function TippyGenerator(tippy) {
         {mounted &&
           createPortal(
             render
-              ? render(toDataAttributes(attrs), singletonContent, mutableBox.current)
+              ? render(toDataAttributes(attrs), singletonContent, mutableBox.instance)
               : content,
             mutableBox.container,
           )}


### PR DESCRIPTION
This change allows to do the following:


```
<Tippy render={(attrs, content, instance) =>
  <button onMousLeave={instance.hideWithInteractivity}>foo</button>
}>bar</Tippy>
```

Without this change, one needs to manually store the instance using the `onCreate` prop