### PR TITLE
feat: expose instance argument from render prop

### DIFF
--- a/src/Tippy.js
+++ b/src/Tippy.js
@@ -221,7 +221,11 @@ export default function TippyGenerator(tippy) {
         {mounted &&
           createPortal(
             render
-              ? render(toDataAttributes(attrs), singletonContent)
+              ? render(
+                  toDataAttributes(attrs),
+                  singletonContent,
+                  mutableBox.instance,
+                )
               : content,
             mutableBox.container,
           )}

--- a/test/Tippy.test.js
+++ b/test/Tippy.test.js
@@ -459,6 +459,25 @@ describe('<Tippy />', () => {
     expect(instance.popper.firstElementChild).toMatchSnapshot();
   });
 
+  test('render prop instance', () => {
+    let _instance;
+    render(
+      <Tippy
+        render={(attrs, content, instance) => {
+          _instance = instance;
+          return <div {...attrs}>Hello</div>;
+        }}
+        showOnCreate={true}
+      >
+        <button />
+      </Tippy>,
+    );
+
+    jest.runAllTimers();
+
+    expect(_instance).toBe(instance);
+  });
+
   test('render prop preserve popperOptions', () => {
     const element = (
       <Tippy


### PR DESCRIPTION
This change allows to do the following:


```
<Tippy render={(attrs, content, instance) =>
  <button onMousLeave={instance.hideWithInteractivity}>foo</button>
}>bar</Tippy>
```

Without this change, one needs to manually store the instance using the `onCreate` prop