### PR TITLE
Singleton now works when Tippys are added

### DIFF
--- a/src/useSingleton.js
+++ b/src/useSingleton.js
@@ -110,7 +110,7 @@ export default function useSingletonGenerator(createSingleton) {
           ) {
             mutableBox.children.push(data);
 
-            if (mutableBox.instance) {
+            if (mutableBox.instance && !mutableBox.instance.state.isDestroyed) {
               mutableBox.instance.setInstances(
                 mutableBox.children.map(child => child.instance),
               );
@@ -122,7 +122,7 @@ export default function useSingletonGenerator(createSingleton) {
             data => data.instance !== instance,
           );
 
-          if (mutableBox.instance) {
+          if (mutableBox.instance && !mutableBox.instance.state.isDestroyed) {
             mutableBox.instance.setInstances(
               mutableBox.children.map(child => child.instance),
             );

--- a/src/useSingleton.js
+++ b/src/useSingleton.js
@@ -109,12 +109,24 @@ export default function useSingletonGenerator(createSingleton) {
             )
           ) {
             mutableBox.children.push(data);
+
+            if (mutableBox.instance) {
+              mutableBox.instance.setInstances(
+                mutableBox.children.map(child => child.instance),
+              );
+            }
           }
         },
         cleanup(instance) {
           mutableBox.children = mutableBox.children.filter(
             data => data.instance !== instance,
           );
+
+          if (mutableBox.instance) {
+            mutableBox.instance.setInstances(
+              mutableBox.children.map(child => child.instance),
+            );
+          }
         },
       };
 

--- a/test/useSingleton.test.js
+++ b/test/useSingleton.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import Tippy, {useSingleton} from '../src';
 import TippyHeadless, {
   useSingleton as useSingletonHeadless,
@@ -167,6 +167,52 @@ describe('disabled prop', () => {
 
     expect(instance.state.isVisible).toBe(false);
   });
+});
+
+it('when new Tippys are added to DOM, they are registered with singleton', () => {
+  const TippyCreator = ({target}) => {
+    const [isTippyAdded, setIsTippyAdded] = useState(false);
+
+    return (
+      <div>
+        <button onClick={() => setIsTippyAdded(true)} data-testid="add-tippy" />
+        {isTippyAdded && (
+          <Tippy content="a" singleton={target}>
+            <button data-testid="a" />
+          </Tippy>
+        )}
+      </div>
+    );
+  };
+
+  function App() {
+    const [source, target] = useSingleton();
+
+    return (
+      <>
+        <Tippy
+          onCreate={onCreate}
+          singleton={source}
+          trigger="click"
+          hideOnClick={false}
+        />
+        <TippyCreator target={target} />
+      </>
+    );
+  }
+
+  const {getByTestId} = render(<App />);
+
+  const addTippyButton = getByTestId('add-tippy');
+
+  fireEvent.click(addTippyButton);
+
+  const buttonA = getByTestId('a');
+
+  fireEvent.click(buttonA);
+
+  expect(instance.state.isVisible).toBe(true);
+  expect(instance.props.content.textContent).toBe('a');
 });
 
 describe('useSingleton headless mode', () => {


### PR DESCRIPTION
This MR updates the singleton logic so that `setInstances` is called when Tippys are added or removed.

This means that you can now dynamically add Tippys when you have a singleton (previously all Tippys needed to be declared when creating the singleton).

This should fix the issue raised here:
https://github.com/atomiks/tippyjs-react/issues/253

---

@atomiks Let me know if you want any tweaks to this MR before merging it (e.g. more tests, docs changes, etc).