### PR TITLE
Change TippyProps['children'] to allow string | number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import {default as tippyCore, Instance, Props, Placement} from 'tippy.js';
 type Content = React.ReactNode;
 
 export interface TippyProps extends Partial<Omit<Props, 'content' | 'render'>> {
-  children?: React.ReactElement<any>;
+  children?: React.ReactChild;
   content?: Content;
   visible?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
React.ReactElement does not include string, but Tippy should/does accept strings as children.

React.ReactChild is defined as:

```typescript
type ReactChild = ReactElement | ReactText;
```